### PR TITLE
Fix PHP version reqs to allow PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": ">=7.2",
         "ext-json": "*",
         "guzzlehttp/guzzle": "~6.0"
     },


### PR DESCRIPTION
I'm using this library to fetch balances and it seems to be working well in this case with PHP8

This PR removes PHP version limit < v8

```
PHP 8.0.6 (cli) (built: May 11 2021 15:49:06) ( NTS )
Copyright (c) The PHP Group
Zend Engine v4.0.6, Copyright (c) Zend Technologies
    with Zend OPcache v8.0.6, Copyright (c), by Zend Technologies
    with Xdebug v3.0.4, Copyright (c) 2002-2021, by Derick Rethans
```

Use case:
```php
        $client = new BittrexClient();
        $client->setCredential($apiKey, $apiSecret);

        $balances = $client->account()->getBalances();
```